### PR TITLE
20486D - Mod 1- Lab 1 - Fixed Typo

### DIFF
--- a/Instructions/20486D_MOD01_LAB_MANUAL.md
+++ b/Instructions/20486D_MOD01_LAB_MANUAL.md
@@ -75,7 +75,7 @@ The main tasks for this exercise are as follows:
 
 1. Create a new **Razor Page** with the following information:
  
-    - Name: **TestPage.cshtml**
+    - Name: **TestPage**
     - Folder: **Pages**
     - Generate PageModel class: **True**
     - Create as a partial view: **False**


### PR DESCRIPTION
Changed New File Name attribute to not include the file extension. If you enter "TestPage.cshtml" into the Name field, VS2017 returns an error saying that page names can't have special characters (the period) in the name. You should use "TestPage" without the file extension.