### PR TITLE
Lab 7 : Clarify db context should go before AddMvc()

### DIFF
--- a/Instructions/20486D_MOD07_LAK.md
+++ b/Instructions/20486D_MOD07_LAK.md
@@ -186,7 +186,7 @@ Ensure that you have cloned the 20486D directory from GitHub (**https://github.c
       }
 ```
 
-13. In the **Startup.cs** code window, in the **ConfigureServices** method, place the cursor after the **{** (opening braces) sign, press Enter, type the following code, and then press Enter.
+13. In the **Startup.cs** code window, in the **ConfigureServices** method, place input the following code on a new line before `services.AddMvc();`, then press enter.
   ```cs
       services.AddDbContext<CupcakeContext>(options =>
              options.UseSqlite("Data Source=cupcake.db"));


### PR DESCRIPTION
If someone misreads this, they might put the code after `services.AddMvc()` where it would have no affect.