### PR TITLE
Lab 09: Change int to int64 for phone number property

### DIFF
--- a/Allfiles/Mod09/Labfiles/01_IceCreamCompany_begin/IceCreamCompany/Models/Customer.cs
+++ b/Allfiles/Mod09/Labfiles/01_IceCreamCompany_begin/IceCreamCompany/Models/Customer.cs
@@ -23,7 +23,7 @@ namespace IceCreamCompany.Models
         public string Email { get; set; }
 
         [Display(Name = "Phone"), DataType(DataType.PhoneNumber)]
-        public int PhoneNumber { get; set; }
+        public int64 PhoneNumber { get; set; }
 
         [Required(ErrorMessage = "Please enter your adress")]
         public string Address { get; set; }


### PR DESCRIPTION
I was curious why my number which begins 770xxxXXXX would throw model invalid.  Turns out it's bigger than the max value of an int.