### PR TITLE
Update 20486D_MOD01_LAK.md with fixes for css paths

### DIFF
--- a/Instructions/20486D_MOD01_LAK.md
+++ b/Instructions/20486D_MOD01_LAK.md
@@ -54,9 +54,9 @@ Estimated Time: **90 minutes**
 
 5. In the **ActorsRazorPages - Microsoft Visual Studio** window, in **Solution Explorer**, expand **Pages**, expand **Shared**, and then click  **_Layout.cshtml**.
 
-6. In the **_Layout.cshtml** code window, in the **HEAD** element, note that is a link to **~/css/site.css**.
+6. In the **_Layout.cshtml** code window, in the **HEAD** element, note that there is a link to **~/css/site.min.css**.
 
-7. In the **ActorsRazorPages - Microsoft Visual Studio** window, in **Solution Explorer**, under **ActorsRazorPages**, expand **wwwroot**, expand **css**, and then click **site.css**
+7. In the **ActorsRazorPages - Microsoft Visual Studio** window, in **Solution Explorer**, under **ActorsRazorPages**, expand **wwwroot**, expand **css**, and then click **site.css**. In the **Solution Explorer**, expand **site.css** and then click **site.min.** and note that this is the minimised version. 
 
     >**Note**: This is the CSS stylesheet file that is applied in the **_Layout.cshtml**.
 
@@ -374,7 +374,7 @@ Estimated Time: **90 minutes**
           return new ObjectResult(item);
        }
 ```
->**Note**: The contents inside the **httpGet** attributes indicate the URL that the user should write to get to the relevant action.
+>**Note**: The contents inside the **HttpGet** attributes indicate the URL that the user should write to get to the relevant action.
 
 18. In the **CakeStoreApi - Microsoft Visual Studio** window, in **Solution Explorer**, click **Startup.cs**.
 
@@ -446,9 +446,9 @@ Estimated Time: **90 minutes**
 
 5. In the **AnimalsMvc - Microsoft Visual Studio** window, in **Solution Explorer**, under **Views**, collapse **Home**, expand **Shared**, and then click **_Layout.cshtml.**
 
-6. In the **_Layout.cshtml** code window, note that in the **HEAD** element there is a link to **~/css/site.css**.
+6. In the **_Layout.cshtml** code window, note that in the **HEAD** element there is a link to **~/css/site.min.css**.
 
-7. In the **AnimalsMvc - Microsoft Visual Studio** window, in **Solution Explorer**, under **AnimalsMvc**, expand **wwwroot**, expand **css**, and then click **site.css**.
+7. In the **AnimalsMvc - Microsoft Visual Studio** window, in **Solution Explorer**, under **AnimalsMvc**, expand **wwwroot**, expand **css**, and then click **site.css**. In the **Solution Explorer**, expand **site.css** and then click **site.min.** and note that this is the minimised version.
 
     >**Note**: This is the CSS stylesheet file that was applied in the **_Layout.cshtml**.
 


### PR DESCRIPTION
Update 20486D_MOD01_LAK.md with fixes for css paths in two places. "~/css/site.css" vs. "~/css/site.min.css", and one minor typo.