### PR TITLE
Fix Erorr: Exercise 1: Use Identity > Task 3: Add sign in logic

### DIFF
--- a/Instructions/20486D_MOD11_LAB_MANUAL.md
+++ b/Instructions/20486D_MOD11_LAB_MANUAL.md
@@ -148,7 +148,7 @@ The main tasks for this exercise are as follows:
 
 10. Add a method with the following information:
     - Scope: **public**
-    - Return type: **Task&lt;IActionResult&gt;**
+    - Return type: **IActionResult**
     - Name: **Login**
 
 11. Create an **IF** statement that checks whether the value of **this.User.Identity.IsAuthenticated** is **true**.


### PR DESCRIPTION
Return type for 'Login' Method in AccountController should be 'IActionResult'. Not 'Task<IActionResult>'.

The respective Detailed steps for this show the code return 'IActionResult' instead of 'Task<IActionResult>'.