### PR TITLE
Fixed a typo where the variable type should be bold.

### DIFF
--- a/Instructions/20486D_MOD04_LAB_MANUAL.md
+++ b/Instructions/20486D_MOD04_LAB_MANUAL.md
@@ -425,7 +425,7 @@ The main tasks for this exercise are as follows:
 
 5. Add a variable named *controllerName* of type **string** and initialize it with the value of **filterContext.ActionDescriptor.RouteValues["controller"]**.
 
-6. Create a variable of type **FileStream(* named *fs* inside a **USING** statement. 
+6. Create a variable of type **FileStream** named *fs* inside a **USING** statement. 
 
 7. Initialize the *fs* variable by using the **FileStream** constructor, and pass it with the following parameters: **_fullPath**, and **FileMode.Create**.  
 


### PR DESCRIPTION
Fixed a typo at exercise 4, task 2, step 6 where the type of the variable was declared as *FileStream( .
Fixed it by replacing the ( with *, the variable type is now bold just like the other type definitions.