### PR TITLE
Bug fix VS2019 on module 6 demo 2

### DIFF
--- a/Allfiles/Mod06/Democode/02_DataAnnotationsExample_begin/DataAnnotationsExample/Controllers/HomeController.cs
+++ b/Allfiles/Mod06/Democode/02_DataAnnotationsExample_begin/DataAnnotationsExample/Controllers/HomeController.cs
@@ -11,7 +11,7 @@ namespace DataAnnotationsExample.Controllers
     {
         public IActionResult Index()
         {
-            return View();
+            return View(new User());
         }
 
         public IActionResult Details(User user)

--- a/Allfiles/Mod06/Democode/02_DataAnnotationsExample_end/DataAnnotationsExample/Controllers/HomeController.cs
+++ b/Allfiles/Mod06/Democode/02_DataAnnotationsExample_end/DataAnnotationsExample/Controllers/HomeController.cs
@@ -11,7 +11,7 @@ namespace DataAnnotationsExample.Controllers
     {
         public IActionResult Index()
         {
-            return View();
+            return View(new User());
         }
 
         public IActionResult Details(User user)


### PR DESCRIPTION
Without this code, VS2019 crashs with a null reference exception. 
(But Visual Studio 2017 does not crash...)