### PR TITLE
typo fix property name should start with uppercase

### DIFF
--- a/Instructions/20486D_MOD01_LAB_MANUAL.md
+++ b/Instructions/20486D_MOD01_LAB_MANUAL.md
@@ -559,7 +559,7 @@ The main tasks for this exercise are as follows:
 9. In the **Animal** model class, add a new property with the following information:
 
     - Scope: **public**
-    - Name: **id**
+    - Name: **Id**
     - Type: **int**
     - Access:  **Read and write**
 


### PR DESCRIPTION
The id in the Animal model class is a property, the name should start with a capital letter according to the naming conventions