### PR TITLE
typo fix, the name should start with an uppercase

### DIFF
--- a/Instructions/20486D_MOD01_LAB_MANUAL.md
+++ b/Instructions/20486D_MOD01_LAB_MANUAL.md
@@ -738,7 +738,7 @@ The main tasks for this exercise are as follows:
 49. In the **ConfigureServices** method, call the **AddSingleton** method of **services** parameter with the following information:
 
     - Interface: **IData**
-    - Implementation: **data**
+    - Implementation: **Data**
 
 
 #### Task 4: Run the application


### PR DESCRIPTION
The name of implementation class of the IData interface should be added as a capital letter